### PR TITLE
Loosen one check safeguard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,14 @@ All notable Changes to the Julia package `Glossaries.jl` are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] January 14, 2026
+
+### Fixed
+
+- Corrected function printing logic in `terms.jl` where the number of arguments check was too restrictive.
+
 ## [0.1.0] January 8, 2026
 
 ### Added
+
 - Initial release of `Glossaries.jl`

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Glossaries"
 uuid = "8f48dd54-e453-4cdc-9500-53b96149560b"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ronny Bergmann <git@ronnybergmann.net>"]
 
 [compat]

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -62,8 +62,6 @@ end
 _print(v::String, args...; kwargs...) = v
 function _print(v::Function, args...; kwargs...)
     # estimate from first function method
-    m = methods(v)[1]
-    (m.nargs != (length(args) + 1)) && return "$(v)"
     return v(args...; kwargs...)
 end
 


### PR DESCRIPTION
Formerly when `_print`ing a `Term` there was a safeguard that checked the number of arguments.
This was too restrictive, since for positional arguments this check was off by the number of positional arguments.

This now instead would just error gracefully if a term property function gets “fed” with the wrong number of arguments, as it already did before for keyword arguments anyways.