### PR TITLE
Fix a small error in Keyword formatter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable Changes to the Julia package `Glossaries.jl` are documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] August 30, 2026
+
+### Fixed
+
+- The `Keyword` formatter now wraps the `default=` in its own code span when a custom `type=` string is given.
+
 ## [0.1.1] January 14, 2026
 
 ### Fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The `Keyword` formatter now wraps the `default=` in its own code span when a custom `type=` string is given.
+- The `Keyword` formatter now keeps ` = default` inside the code span when a custom `type=` string is given, matching the documented `` `name::type = default` `` format.
 
 ## [0.1.1] January 14, 2026
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Glossaries"
 uuid = "8f48dd54-e453-4cdc-9500-53b96149560b"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ronny Bergmann <git@ronnybergmann.net>"]
 
 [compat]

--- a/src/format.jl
+++ b/src/format.jl
@@ -256,20 +256,10 @@ function (kw::Keyword)(term::Term, args...; default = "", name = "", type = "", 
     name = length(name) > 0 ? name : get(term.properties, :name, "")
     df = length(default) > 0 ? default : _print(term, :default, args...; kwargs...)
     s = "- `$(name)"
-    closed = false # a custom `type` closes the code span itself
     if (haskey(term.properties, :type) || length(type) > 0) && kw.show_type
-        if length(type) > 0
-            s *= "::$(type)`"
-            closed = true
-        else
-            s *= "::$(_print(term, :type, args...; kwargs...))"
-        end
+        s *= "::" * (length(type) > 0 ? type : _print(term, :type, args...; kwargs...))
     end
-    if closed
-        (length(df) > 0) && (s *= " = `$(df)`")
-    else
-        s *= length(df) > 0 ? " = $(df)`" : "`"
-    end
+    s *= length(df) > 0 ? " = $(df)`" : "`"
     s *= ": $(_print(term, :description, args...; kwargs...))"
     for p in add_properties
         if haskey(term.properties, p)

--- a/src/format.jl
+++ b/src/format.jl
@@ -256,10 +256,20 @@ function (kw::Keyword)(term::Term, args...; default = "", name = "", type = "", 
     name = length(name) > 0 ? name : get(term.properties, :name, "")
     df = length(default) > 0 ? default : _print(term, :default, args...; kwargs...)
     s = "- `$(name)"
+    closed = false # a custom `type` closes the code span itself
     if (haskey(term.properties, :type) || length(type) > 0) && kw.show_type
-        s *= length(type) > 0 ? "::$(type)`" : "::$(_print(term, :type, args...; kwargs...))"
+        if length(type) > 0
+            s *= "::$(type)`"
+            closed = true
+        else
+            s *= "::$(_print(term, :type, args...; kwargs...))"
+        end
     end
-    s *= length(df) > 0 ? " = $(df)`" : "`"
+    if closed
+        (length(df) > 0) && (s *= " = `$(df)`")
+    else
+        s *= length(df) > 0 ? " = $(df)`" : "`"
+    end
     s *= ": $(_print(term, :description, args...; kwargs...))"
     for p in add_properties
         if haskey(term.properties, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,10 @@ g = Glossaries.@Glossary()
         @test contains(s4, "`manifold::AbstractManifold = Sphere(2)`")
         @test contains(s4, "a Riemannian manifold")
         @test contains(kw(t; add_properties = [:note]), " (finite dimensional)")
+        # a custom `type` closes the code span, so the default gets its own span
+        s4b = kw(t; type = "Union{`[`A`](@ref)`, Missing}", default = "missing")
+        @test contains(s4b, "`manifold::Union{`[`A`](@ref)`, Missing}` = `missing`")
+        @test iseven(count(==('`'), s4b))
 
         p = Glossaries.@Plain()
         @test Glossaries.Plain() === p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,9 +55,9 @@ g = Glossaries.@Glossary()
         @test contains(s4, "`manifold::AbstractManifold = Sphere(2)`")
         @test contains(s4, "a Riemannian manifold")
         @test contains(kw(t; add_properties = [:note]), " (finite dimensional)")
-        # a custom `type` closes the code span, so the default gets its own span
+        # a custom `type` leaves the code span open, so ` = default` stays in code
         s4b = kw(t; type = "Union{`[`A`](@ref)`, Missing}", default = "missing")
-        @test contains(s4b, "`manifold::Union{`[`A`](@ref)`, Missing}` = `missing`")
+        @test contains(s4b, "`manifold::Union{`[`A`](@ref)`, Missing} = missing`")
         @test iseven(count(==('`'), s4b))
 
         p = Glossaries.@Plain()


### PR DESCRIPTION
where providing type and default caused the backticks to be slightly off.